### PR TITLE
block-model - proposal for changing order of product param defaults

### DIFF
--- a/components/block-model/block-model.liquid
+++ b/components/block-model/block-model.liquid
@@ -10,7 +10,7 @@
 {%- endcomment -%}
 
 {% liquid
-  assign product = product | default: block.settings.product
+  assign product = block.settings.product | default: product
   assign media = media | default: product.media | where: 'media_type', 'model' | first
   assign autoplay = autoplay | default: block.settings.autoplay
   assign media_crop = media_crop | default: block.settings.media_crop | default: 'square'


### PR DESCRIPTION
Currently, we have `assign product = product | default: block.settings.product` in the block-model component

The issue is that when we add a product to the block from within the editor, we don't see this product show up. 

Expectation: when we choose a product with a 3D model media type, it will render within the section

The only way a product will show right now is if we happen to be on a product template that has a model within its media

I think the better UX is for the `product` to be the fallback, not the block setting