### PR TITLE
Add eager loading to icon component + header icon

### DIFF
--- a/components/cart-icon/cart-icon.liquid
+++ b/components/cart-icon/cart-icon.liquid
@@ -18,7 +18,7 @@
 
 <is-land on:idle>
   <a href="{{ routes.cart_url }}" class="cart-icon">
-    {%- render 'icon', name: name -%}
+    {%- render 'icon', name: name, eager: true -%}
 
     <div class="cart-count">
       <cart-count

--- a/components/icon/icon.liquid
+++ b/components/icon/icon.liquid
@@ -6,9 +6,11 @@
   - directory {string} - Directory of the icon (optional)
   - prepend {boolean} - Prepends the icon name with a string (optional)
   - hydration {'on:visible'|'on:idle'|'on:interaction'|'on:media'} - Hydration strategy
+  - eager {boolean} - Enables/disables eager loading if wrapped by <is-land> element (optional)
 
   Usage:
   {% render 'icon', name: 'alert' %}
+  {% render 'icon', name: 'alert', eager: true %}
 {% endcomment %}
 
 {%- liquid
@@ -33,10 +35,12 @@
 
 <is-land {{ hydration }}>
   <x-icon
+    {% if eager %}
+      defer-hydration
+    {% endif %}
     src="{{ url }}"
     name="{{ name }}"
-  >
-  </x-icon>
+  ></x-icon>
 
   <template data-island>
     <script type="module">


### PR DESCRIPTION
Any custom elements inside an `<is-land>` have their `connectedCallback()` function delayed until the island is hydrated. This was working against our icon approach and delaying the downloading and setting of icon svgs until `on:idle`, aka when page completed loading.

The lib we use for <is-land> comes with `defer-hydration` functionality ([read more here](https://www.zachleat.com/web/defer-hydration/)) which when applied to our icon element allows them to be loaded eagerly. Adding this as a param since the default functionality works well in most cases!